### PR TITLE
Adiciona permissão ao verbo HTTP OPTIONS

### DIFF
--- a/src/main/java/com/pucpr/byteplace/config/SecurityFilter.java
+++ b/src/main/java/com/pucpr/byteplace/config/SecurityFilter.java
@@ -32,6 +32,7 @@ public class SecurityFilter {
                 .authorizeHttpRequests(authConfig -> {
                     authConfig.requestMatchers(HttpMethod.POST, "/auth/authenticate").permitAll();
                     authConfig.requestMatchers(HttpMethod.POST, "/auth/register").permitAll();
+                    authConfig.requestMatchers(HttpMethod.OPTIONS, "/auth/**").permitAll();
                     authConfig.requestMatchers("/error").permitAll();
 
                     authConfig.requestMatchers(HttpMethod.GET, "/product").hasAuthority(Permission.VISUALIZAR_PRODUTO.name());


### PR DESCRIPTION
O browser sempre envia uma solicitação com verbo http OPTIONS, que diz quais verbos o backend aceita, antes de fazer a requisição. Precisa dar permissão pra ele também.